### PR TITLE
Prepare maven SNAPSHOT version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /petstore
 
 ENV OPENAPI_BASE_PATH=/v3
 
-COPY target/openapi-petstore-3.0.0.jar /petstore/openapi-petstore.jar
+COPY target/openapi-petstore.jar /petstore/openapi-petstore.jar
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ mvn spring-boot:run
 Or package it then run it as a Java application
 ```
 mvn package
-java -jar target/openapi-petstore-{VERSION}.jar
+java -jar target/openapi-petstore.jar
 ```
 
 You can view the api documentation in swagger-ui by pointing to  

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.openapitools</groupId>
+    <groupId>org.openapitools.petstore</groupId>
     <artifactId>openapi-petstore</artifactId>
     <packaging>jar</packaging>
     <name>openapi-petstore</name>
-    <version>3.0.0</version>
+    <version>3.0.0-SNAPSHOT</version>
     <properties>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -15,6 +15,7 @@
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.0.2.RELEASE</version>
     </parent>
+    <url>https://github.com/openapitools/openapi-petstore</url>
     <licenses>
         <license>
             <name>Apache License 2.0</name>
@@ -23,6 +24,7 @@
         </license>
     </licenses>
     <build>
+        <finalName>openapi-petstore</finalName>
         <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>
             <plugin>
@@ -117,4 +119,40 @@
             <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
+    <scm>
+        <connection>scm:git:git@github.com:openapitools/openapi-petstore.git</connection>
+        <developerConnection>scm:git:git@github.com:openapitools/openapi-petstore.git</developerConnection>
+        <url>https://github.com/openapitools/openapi-petstore</url>
+    </scm>
+    <developers>
+        <developer>
+            <id>cbornet</id>
+            <name>Christophe Bornet</name>
+            <email>cbornet@hotmail.com</email>
+        </developer>
+        <developer>
+            <id>wing328</id>
+            <name>William Cheng</name>
+            <email>wing328hk@gmail.com</email>
+        </developer>
+        <developer>
+            <id>jmini</id>
+            <name>Jérémie Bresson</name>
+            <email>dev@jmini.fr</email>
+        </developer>
+    </developers>
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/openapitools/openapi-generator/issues</url>
+    </issueManagement>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
This PR prepares the possibility to deploy the artifacts to a maven repository (in addition to the docker image).

* Version is now `3.0.0-SNAPSHOT` to add the possibility to perform releases
*.Produced jar (in the `target/` folder) is now `openapi-petstore.jar` instead of `openapi-petstore-${version}.jar`
* Add necessary maven metadata for publication on maven-central
* `groupId ` changed to `org.openapitools.petstore` to be more consistent with other projects.
* Readme and Dockerfile are updated to reflect the changes
