### PR TITLE
Fix internal server by tightening API spec

### DIFF
--- a/src/main/java/org/openapitools/api/StoreApiDelegateImpl.java
+++ b/src/main/java/org/openapitools/api/StoreApiDelegateImpl.java
@@ -46,8 +46,8 @@ public class StoreApiDelegateImpl implements StoreApiDelegate {
 
 
     @Override
-    public ResponseEntity<Void> deleteOrder(String orderId) {
-        Order order = orderRepository.findById(Long.valueOf(orderId))
+    public ResponseEntity<Void> deleteOrder(Long orderId) {
+        Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
         orderRepository.delete(order);
         return ResponseEntity.ok().build();

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -382,7 +382,8 @@ paths:
         style: simple
         explode: false
         schema:
-          type: string
+          type: integer
+          format: int64
       responses:
         400:
           description: Invalid ID supplied
@@ -598,6 +599,8 @@ components:
     Order:
       title: Pet Order
       type: object
+      required:
+        - id
       properties:
         id:
           type: integer
@@ -649,6 +652,9 @@ components:
     User:
       title: a User
       type: object
+      required:
+        - id
+        - username
       properties:
         id:
           type: integer


### PR DESCRIPTION
By specifying more constraints in the openapi.yaml file we can avoid possible exceptions and internal server errors and instead get descriptive validation messages on bad input.

The

    curl -D- -X POST -H "Content-Type: application/json" --data "{}" http://localhost:8080/v3/store/order

request previously returned:

```
HTTP/1.1 500
<Map><timestamp>2020-05-08T08:00:36.259Z</timestamp><status>500</status><error>Internal Server Error</error><message>entity ID cannot be null</message><path>/v3/store/order</path></Map>
```

After this change it returns:

```
HTTP/1.1 400
<Map><timestamp>2020-05-08T08:03:46.408Z</timestamp><status>400</status><error>Bad Request</error><errors><codes><codes>NotNull.order.id</codes><codes>NotNull.id</codes><codes>NotNull.java.lang.Long</codes><codes>NotNull</codes></codes><arguments><arguments><codes><codes>order.id</codes><codes>id</codes></codes><defaultMessage>id</defaultMessage><code>id</code></arguments></arguments><defaultMessage>must not be null</defaultMessage><objectName>order</objectName><field>id</field><rejectedValue/><bindingFailure>false</bindingFailure><code>NotNull</code></errors><message>Validation failed for object='order'. Error count: 1</message><path>/v3/store/order</path></Map>
```

The

    curl -D- -X DELETE http://localhost:8080/v3/store/order/-

request previously returned:

```
HTTP/1.1 500
{"timestamp":"2020-05-08T08:01:49.014Z","status":500,"error":"Internal Server Error","message":"For input string: \"-\"","path":"/v3/store/order/-"}
```

After this change it returns:

```
HTTP/1.1 400
{"timestamp":"2020-05-08T08:04:16.419Z","status":400,"error":"Bad Request","message":"Failed to convert value of type 'java.lang.String' to required type 'java.lang.Long'; nested exception is java.lang.NumberFormatException: For input string: \"-\"","path":"/v3/store/order/-"}
```

The

    curl -D- -X POST -H "Content-Type: application/json" --data "{}" http://localhost:8080/v3/user

request previously returned:

```
HTTP/1.1 500
{"timestamp":"2020-05-08T08:02:27.174Z","status":500,"error":"Internal Server Error","message":"entity ID cannot be null","path":"/v3/user"}
```

After this change it returns:

```
HTTP/1.1 400
{"timestamp":"2020-05-08T08:04:38.026Z","status":400,"error":"Bad Request","errors":[{"codes":["NotNull.user.id","NotNull.id","NotNull.java.lang.Long","NotNull"],"arguments":[{"codes":["user.id","id"],"arguments":null,"defaultMessage":"id","code":"id"}],"defaultMessage":"must not be null","objectName":"user","field":"id","rejectedValue":null,"bindingFailure":false,"code":"NotNull"},{"codes":["NotNull.user.username","NotNull.username","NotNull.java.lang.String","NotNull"],"arguments":[{"codes":["user.username","username"],"arguments":null,"defaultMessage":"username","code":"username"}],"defaultMessage":"must not be null","objectName":"user","field":"username","rejectedValue":null,"bindingFailure":false,"code":"NotNull"}],"message":"Validation failed for object='user'. Error count: 2","path":"/v3/user"}
```

These issues were found while trying out https://meeshkan.com/ on this repository.